### PR TITLE
#38: New `update_one` method

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
+            toolchain: stable
             override: true
             components: rustfmt, clippy
 


### PR DESCRIPTION
New `update_one` method enables library users to update a single entry in the index.

This is useful for scenarios where we performed some action on a resource and want to quickly adjust app model with the index. More details in the issue:
- #38 

The usage in an app should be like this:
1. App has the index. It is allowed to be slightly outdated.
2. User deletes or edits a resource. New resource by the same path has different content.
3. Full updating using `update_all` would spend some time and user could be annoyed by necessity to wait before they can move to next resource in their selection. That's why we call `update_one` and pass path of the edited resource.
4. We receive update from the index and handle it uniformly to any external updates.
5. Since we used this `update_one` method, **the index still can be outdated**, same as in step 1. That's fine because the app model and the index are in sync.
6. When the user is done with their selection, we can call `update_all` and catch up with external updates to the filesystem.