### PR TITLE
Add error for different use case

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,10 @@ lazy_static = "1.4.0"
 canonical-path = "2.0.2"
 pathdiff = "0.2.1"
 image = "0.24.2"
-pdfium-render = { git = "https://github.com/ajrcarey/pdfium-render", rev = "d2559c1",features = ["thread_safe", "sync"] }
+pdfium-render = { git = "https://github.com/ajrcarey/pdfium-render", rev = "d2559c1", features = [
+    "thread_safe",
+    "sync",
+] }
 libloading = "0.7.3"
 serde_json = "1.0.82"
 serde = { version = "1.0.138", features = ["derive"] }
@@ -28,6 +31,7 @@ zip = "0.6.2"
 tokio = { version = "1", features = ["full"] }
 itertools = "0.10.5"
 once_cell = "1.16.0"
+thiserror = "1"
 
 [dev-dependencies]
 tempdir = "0.3.7"
@@ -40,4 +44,3 @@ libloading = "0.7.3"
 tar = "0.4.38"
 target-lexicon = "0.12.4"
 ureq = "2.4.0"
-

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,33 @@
+use std::str::Utf8Error;
+
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, ArklibError>;
+
+#[derive(Error, Debug)]
+pub enum ArklibError {
+    #[error("IO error")]
+    Io(#[from] std::io::Error),
+    #[error("Invalid path for ressource")]
+    Path,
+    #[error("There is some collision: {0}")]
+    Collision(String),
+    #[error("Parsing error")]
+    Parse,
+    #[error("Networking error")]
+    Network,
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl From<reqwest::Error> for ArklibError {
+    fn from(_: reqwest::Error) -> Self {
+        Self::Network
+    }
+}
+
+impl From<Utf8Error> for ArklibError {
+    fn from(_: Utf8Error) -> Self {
+        Self::Parse
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,8 +8,8 @@ pub type Result<T> = std::result::Result<T, ArklibError>;
 pub enum ArklibError {
     #[error("IO error")]
     Io(#[from] std::io::Error),
-    #[error("Invalid path for ressource")]
-    Path,
+    #[error("Path error: {0}")]
+    Path(String),
     #[error("There is some collision: {0}")]
     Collision(String),
     #[error("Parsing error")]

--- a/src/index.rs
+++ b/src/index.rs
@@ -14,7 +14,7 @@ use walkdir::{DirEntry, WalkDir};
 use log;
 
 use crate::id::ResourceId;
-use crate::{ARK_FOLDER, ArklibError, Result, INDEX_PATH};
+use crate::{ArklibError, Result, ARK_FOLDER, INDEX_PATH};
 
 #[derive(Eq, Ord, PartialEq, PartialOrd, Hash, Clone, Debug)]
 pub struct IndexEntry {
@@ -376,7 +376,7 @@ impl ResourceIndex {
 
                             // the caller must have ensured that the path was updated
                             return Err(ArklibError::Collision(
-                                "Nothing to update".into(),
+                                "New content has the same id".into(),
                             ));
                         }
 
@@ -453,7 +453,7 @@ impl ResourceIndex {
                 );
             } else {
                 return Err(ArklibError::Collision(
-                    "New content has the same id.".into(),
+                    "Illegal state of collision tracker".into(),
                 ));
             }
         } else {
@@ -510,7 +510,7 @@ fn discover_paths<P: AsRef<Path>>(
 
 fn scan_entry(path: &CanonicalPath, metadata: Metadata) -> Result<IndexEntry> {
     if metadata.is_dir() {
-        return Err(ArklibError::Path("Metadata is a directory".into()));
+        return Err(ArklibError::Path("Path is expected to be a file".into()));
     }
 
     let size = metadata.len();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 extern crate lazy_static;
 extern crate canonical_path;
+pub mod errors;
+pub use errors::{ArklibError, Result};
 pub mod id;
 pub mod link;
 pub mod pdf;
@@ -16,7 +18,6 @@ use std::sync::{Arc, RwLock};
 
 use canonical_path::CanonicalPathBuf;
 
-use anyhow::Error;
 use log;
 
 pub const ARK_FOLDER: &str = ".ark";
@@ -45,7 +46,7 @@ lazy_static! {
 
 pub fn provide_index<P: AsRef<Path>>(
     root_path: P,
-) -> Result<Arc<RwLock<ResourceIndex>>, Error> {
+) -> Result<Arc<RwLock<ResourceIndex>>> {
     let root_path = CanonicalPathBuf::canonicalize(root_path)?;
 
     {

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,4 +1,3 @@
-use anyhow::Error;
 use reqwest::header::HeaderValue;
 use scraper::{Html, Selector};
 use serde::{Deserialize, Serialize};
@@ -10,7 +9,7 @@ use url::Url;
 
 use crate::id::ResourceId;
 use crate::meta::{load_meta_bytes, store_meta};
-use crate::{ARK_FOLDER, PREVIEWS_STORAGE_FOLDER};
+use crate::{ARK_FOLDER, ArklibError, Result, PREVIEWS_STORAGE_FOLDER};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Link {
@@ -27,23 +26,24 @@ pub struct Metadata {
 impl Link {
     pub fn new(url: Url, title: String, desc: Option<String>) -> Self {
         Self {
-            url: url,
+            url,
             meta: Metadata { title, desc },
         }
     }
 
-    pub fn id(&self) -> Result<ResourceId, Error> {
+    pub fn id(&self) -> Result<ResourceId> {
         ResourceId::compute_bytes(self.url.as_str().as_bytes())
     }
 
     /// Load a link with its metadata from file
-    pub fn load<P: AsRef<Path>>(root: P, path: P) -> Result<Self, Error> {
+    pub fn load<P: AsRef<Path>>(root: P, path: P) -> Result<Self> {
         let p = path.as_ref().to_path_buf();
         let url = Self::load_url(p)?;
         let id = ResourceId::compute_bytes(url.as_str().as_bytes())?;
 
         let bytes = load_meta_bytes::<PathBuf>(root.as_ref().to_owned(), id)?;
-        let meta: Metadata = serde_json::from_slice(&bytes)?;
+        let meta: Metadata =
+            serde_json::from_slice(&bytes).map_err(|_| ArklibError::Parse)?;
 
         Ok(Self { url, meta })
     }
@@ -54,7 +54,7 @@ impl Link {
         root: P,
         path: P,
         save_preview: bool,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         let id = self.id()?;
         store_meta::<Metadata, _>(root.as_ref(), id, &self.meta)?;
 
@@ -82,7 +82,7 @@ impl Link {
         root: P,
         path: P,
         save_preview: bool,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         let runtime = tokio::runtime::Runtime::new()?;
         runtime.block_on(self.write_to_path(root, path, save_preview))
     }
@@ -92,7 +92,7 @@ impl Link {
         root: P,
         image_data: Vec<u8>,
         id: ResourceId,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         let path = root
             .as_ref()
             .join(ARK_FOLDER)
@@ -108,7 +108,7 @@ impl Link {
     }
 
     /// Get metadata of the link (synced).
-    pub fn get_preview_synced<S>(url: S) -> Result<OpenGraph, reqwest::Error>
+    pub fn get_preview_synced<S>(url: S) -> Result<OpenGraph>
     where
         S: Into<String>,
     {
@@ -118,7 +118,7 @@ impl Link {
     }
 
     /// Get metadata of the link.
-    pub async fn get_preview<S>(url: S) -> Result<OpenGraph, reqwest::Error>
+    pub async fn get_preview<S>(url: S) -> Result<OpenGraph>
     where
         S: Into<String>,
     {
@@ -152,10 +152,10 @@ impl Link {
         })
     }
 
-    fn load_url(path: PathBuf) -> Result<Url, Error> {
+    fn load_url(path: PathBuf) -> Result<Url> {
         let url_raw = std::fs::read(path)?;
         let url_str = str::from_utf8(url_raw.as_slice())?;
-        Ok(Url::from_str(url_str)?)
+        Url::from_str(url_str).map_err(|_| ArklibError::Parse)
     }
 }
 

--- a/src/link.rs
+++ b/src/link.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 use crate::id::ResourceId;
 use crate::meta::{load_meta_bytes, store_meta};
-use crate::{ARK_FOLDER, ArklibError, Result, PREVIEWS_STORAGE_FOLDER};
+use crate::{ArklibError, Result, ARK_FOLDER, PREVIEWS_STORAGE_FOLDER};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Link {

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -2,11 +2,10 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::path::Path;
 
-use anyhow::Error;
 use serde::Serialize;
 
 use crate::id::ResourceId;
-use crate::{ARK_FOLDER, METADATA_STORAGE_FOLDER};
+use crate::{ARK_FOLDER, ArklibError, Result, METADATA_STORAGE_FOLDER};
 
 /// Dynamic metadata: stored as JSON and
 /// interpreted differently depending on kind of a resource
@@ -14,7 +13,7 @@ pub fn store_meta<S: Serialize, P: AsRef<Path>>(
     root: P,
     id: ResourceId,
     metadata: &S,
-) -> Result<(), Error> {
+) -> Result<()> {
     let path = root
         .as_ref()
         .join(ARK_FOLDER)
@@ -22,7 +21,8 @@ pub fn store_meta<S: Serialize, P: AsRef<Path>>(
     fs::create_dir_all(path.to_owned())?;
     let mut file = File::create(path.to_owned().join(id.to_string()))?;
 
-    let json = serde_json::to_string(&metadata)?;
+    let json =
+        serde_json::to_string(&metadata).map_err(|_| ArklibError::Parse)?;
     let _ = file.write(json.into_bytes().as_slice())?;
 
     Ok(())
@@ -32,7 +32,7 @@ pub fn store_meta<S: Serialize, P: AsRef<Path>>(
 pub fn load_meta_bytes<P: AsRef<Path>>(
     root: P,
     id: ResourceId,
-) -> Result<Vec<u8>, Error> {
+) -> Result<Vec<u8>> {
     let storage = root
         .as_ref()
         .join(ARK_FOLDER)

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use serde::Serialize;
 
 use crate::id::ResourceId;
-use crate::{ARK_FOLDER, ArklibError, Result, METADATA_STORAGE_FOLDER};
+use crate::{ArklibError, Result, ARK_FOLDER, METADATA_STORAGE_FOLDER};
 
 /// Dynamic metadata: stored as JSON and
 /// interpreted differently depending on kind of a resource


### PR DESCRIPTION
Define custom errors type. More type could be use if needed and remove the anyhow completely. Anyhow is better for application developper who want to manage every errors. For a library it's better to provide different errors and let the consumer decide what to do
https://github.com/ARK-Builders/arklib/issues/43