### PR TITLE
Replaced id2path with a function call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+Cargo.lock


### PR DESCRIPTION
Putting this out there as an alternative to the current struct. The resource lists are duplicated, but also get out of sync with collisions. This removes id2path and replaces all current uses with path2id. For future use id2path is also now a function call.

* Modified all previous key searches using it.
* Added some function doc notes
* Fixed target_os -> target_family for unix file permissions 
* Removed a few noop test assertions