### PR TITLE
put .unwrap() instead ?

### DIFF
--- a/src/atomic/file.rs
+++ b/src/atomic/file.rs
@@ -44,7 +44,7 @@ impl Drop for TmpFile {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ReadOnlyFile {
     version: usize,
     path: PathBuf,
@@ -101,12 +101,12 @@ fn parse_version(filename: Option<&str>) -> Option<usize> {
 
 impl AtomicFile {
     pub fn new(path: impl Into<PathBuf>) -> crate::Result<Self> {
-        let directory = path.into();
+        let directory: PathBuf = path.into();
         // This UID must be treated as confidential information.
         // Depending on network transport used to sync the files (if any),
         // it can leak to an unauthorized party.
-        let machine_id = machine_uid::get()?;
-        std::fs::create_dir_all(&directory)?;
+        let machine_id = machine_uid::get().unwrap();
+        std::fs::create_dir_all(&directory).unwrap();
         let filename: &str = match directory.file_name() {
             Some(name) => name.to_str().unwrap(),
             None => Err(std::io::Error::new(
@@ -163,7 +163,7 @@ impl AtomicFile {
     }
 
     pub fn load(&self) -> Result<ReadOnlyFile> {
-        let (version, mut files) = self.latest_version()?;
+        let (version, mut files) = self.latest_version().unwrap();
         let file = match files.len() {
             0 => ReadOnlyFile {
                 version,

--- a/src/link.rs
+++ b/src/link.rs
@@ -23,6 +23,7 @@ pub struct Link {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Properties {
     pub title: String,
+    #[serde(alias = "description")]
     pub desc: Option<String>,
 }
 /// Write data to a tempory file and move that written file to destination
@@ -61,10 +62,10 @@ impl Link {
             .join(ARK_FOLDER)
             .join(PROPERTIES_STORAGE_FOLDER)
             .join(id.to_string());
-        let file = AtomicFile::new(path)?;
-        let current = file.load()?;
-        let data = current.read_to_string()?;
-        let user_meta: Properties = serde_json::from_str(&data)?;
+        let file = AtomicFile::new(path).unwrap();
+        let current = file.load().unwrap();
+        let data = current.clone().read_to_string().unwrap();
+        let user_meta: Properties = serde_json::from_str(&data).unwrap();
         Ok(user_meta)
     }
 


### PR DESCRIPTION
This PR change `?` to `.unwrap()` because when ARK-Shelf-Desktop call some of function in the library, function calls that has `?` doesn't return a correct result and caused the operation stuck.