### PR TITLE
#41: Add unit tests, fix update_one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 **/app_id
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ uuid = { version = "1.6.1", features = ["v4"] }
 [dev-dependencies]
 tempdir = "0.3.7"
 rstest = '0.18.2'
+rand = "0.8.5"
 
 [build-dependencies]
 flate2 = "1.0.24"

--- a/src/storage/meta.rs
+++ b/src/storage/meta.rs
@@ -38,6 +38,7 @@ pub fn store_metadata<
 }
 
 /// The file must exist if this method is called
+#[allow(dead_code)]
 pub fn load_raw_metadata<P: AsRef<Path>>(
     root: P,
     id: ResourceId,


### PR DESCRIPTION
Here are couple more tests.

`update_one` was handling absent paths incorrectly, fixed here.

Closing:
- #41