### PR TITLE
#65: Replace `CRC32` with `BLAKE3`  Hash Function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tempdir = "0.3.7"
 rstest = '0.18.2'
 # benchmarking
 criterion = { version = "0.5", features = ["html_reports"] }
+rand = "0.8"
 
 [build-dependencies]
 flate2 = "1.0.24"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ uuid = { version = "1.6.1", features = ["v4"] }
 [dev-dependencies]
 tempdir = "0.3.7"
 rstest = '0.18.2'
+# benchmarking
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [build-dependencies]
 flate2 = "1.0.24"
@@ -47,3 +49,8 @@ tar = "0.4.38"
 target-lexicon = "0.12.4"
 ureq = "2.4.0"
 ring = "=0.17.5"
+
+[[bench]]
+name = "hash_benchmark"
+harness = false
+path = "benches/hash_benchmark.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ once_cell = "1.16.0"
 thiserror = "1"
 fastrand = "2"
 uuid = { version = "1.6.1", features = ["v4"] }
+base64 = "0.21"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 log = { version = "0.4.17", features = ["release_max_level_off"] }
-crc32fast = "1.3.2"
+blake3 = "1.5"
 walkdir = "2.3.2"
 anyhow = "1.0.58"
 env_logger = "0.9.0"

--- a/benches/hash_benchmark.rs
+++ b/benches/hash_benchmark.rs
@@ -1,14 +1,21 @@
 use arklib::id::ResourceId;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand::prelude::*;
+
+fn generate_random_data(size: usize) -> Vec<u8> {
+    let mut rng = rand::thread_rng();
+    (0..size).map(|_| rng.gen()).collect()
+}
 
 fn compute_bytes_benchmark(c: &mut Criterion) {
     let inputs = [
-        ("compute_bytes_small", vec![0u8; 64]),
-        ("compute_bytes_medium", vec![1u8; 512]),
-        ("compute_bytes_large", vec![2u8; 4096]),
+        ("compute_bytes_small", 64),
+        ("compute_bytes_medium", 512),
+        ("compute_bytes_large", 4096),
     ];
 
-    for (name, input_data) in inputs.iter() {
+    for (name, size) in inputs.iter() {
+        let input_data = generate_random_data(*size);
         c.bench_function(name, move |b| {
             b.iter(|| {
                 if let Ok(result) =

--- a/benches/hash_benchmark.rs
+++ b/benches/hash_benchmark.rs
@@ -1,0 +1,27 @@
+use arklib::id::ResourceId;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn compute_bytes_benchmark(c: &mut Criterion) {
+    let inputs = [
+        ("compute_bytes_small", vec![0u8; 64]),
+        ("compute_bytes_medium", vec![1u8; 512]),
+        ("compute_bytes_large", vec![2u8; 4096]),
+    ];
+
+    for (name, input_data) in inputs.iter() {
+        c.bench_function(name, move |b| {
+            b.iter(|| {
+                if let Ok(result) =
+                    ResourceId::compute_bytes(black_box(&input_data))
+                {
+                    black_box(result);
+                } else {
+                    panic!("compute_bytes returned an error");
+                }
+            });
+        });
+    }
+}
+
+criterion_group!(benches, compute_bytes_benchmark);
+criterion_main!(benches);

--- a/src/atomic/file.rs
+++ b/src/atomic/file.rs
@@ -52,7 +52,8 @@ pub struct ReadOnlyFile {
     pub path: PathBuf,
 }
 
-/// This struct is the only way to read the file. Both path and version are private
+/// This struct is the only way to read the file. Both path and version are
+/// private
 impl ReadOnlyFile {
     /// Open the underlying file, which can be read from but not written to.
     /// May return `Ok(None)`, which means that no version

--- a/src/atomic/mod.rs
+++ b/src/atomic/mod.rs
@@ -79,7 +79,8 @@ mod tests {
                 let current = file.load().unwrap();
                 let content = format!("Content from thread {i}!");
                 (&temp).write_all(content.as_bytes()).unwrap();
-                // In case slow computer ensure each thread are running in the same time
+                // In case slow computer ensure each thread are running in the
+                // same time
                 std::thread::sleep(std::time::Duration::from_millis(300));
                 file.compare_and_swap(&current, temp)
             });
@@ -108,7 +109,8 @@ mod tests {
         let shared_file = std::sync::Arc::new(AtomicFile::new(root).unwrap());
         let thread_number = 10;
         assert!(thread_number > 3);
-        // Need to have less than 255 thread to store thread number as byte directly
+        // Need to have less than 255 thread to store thread number as byte
+        // directly
         assert!(thread_number < 256);
         let mut handles = Vec::with_capacity(thread_number);
         for i in 0..thread_number {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,8 +10,6 @@ pub enum ArklibError {
     Io(#[from] std::io::Error),
     #[error("Path error: {0}")]
     Path(String),
-    #[error("There is some collision: {0}")]
-    Collision(String),
     #[error("Parsing error")]
     Parse,
     #[error("Networking error")]

--- a/src/id.rs
+++ b/src/id.rs
@@ -12,17 +12,25 @@ use std::str::FromStr;
 use crate::{ArklibError, Result};
 
 #[derive(
-    Eq, Ord, PartialEq, PartialOrd, Hash, Clone, Debug, Deserialize, Serialize,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Hash,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    Serialize,
 )]
 pub struct ResourceId {
     pub data_size: u64,
-    /// blake3 hash (hex string)
-    pub blake3: String,
+    pub blake3: [u8; 32],
 }
 
 impl Display for ResourceId {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}-{}", self.data_size, self.blake3)
+        write!(f, "{}-{:?}", self.data_size, self.blake3)
     }
 }
 
@@ -32,8 +40,18 @@ impl FromStr for ResourceId {
     fn from_str(s: &str) -> Result<Self> {
         let (l, r) = s.split_once('-').ok_or(ArklibError::Parse)?;
         let data_size: u64 = l.parse().map_err(|_| ArklibError::Parse)?;
-        let blake3 = r.to_string();
-
+        let s = r.trim_start_matches('[').trim_end_matches(']');
+        let bytes: Vec<&str> = s.split(", ").collect();
+        if bytes.len() != 32 {
+            return Err(ArklibError::Parse);
+        }
+        let mut blake3 = [0u8; 32];
+        for (i, byte_str) in bytes.iter().enumerate() {
+            blake3[i] = byte_str
+                .trim()
+                .parse()
+                .map_err(|_e| ArklibError::Parse)?;
+        }
         Ok(ResourceId { data_size, blake3 })
     }
 }
@@ -91,12 +109,15 @@ impl ResourceId {
                 })?;
         }
 
-        let blake3 = hasher.finalize().to_hex().to_string();
+        let blake3 = hasher.finalize();
         log::trace!("[compute] {} bytes has been read", bytes_read);
         log::trace!("[compute] blake3 hash: {}", blake3);
         assert_eq!(std::convert::Into::<u64>::into(bytes_read), data_size);
 
-        Ok(ResourceId { data_size, blake3 })
+        Ok(ResourceId {
+            data_size,
+            blake3: blake3.into(),
+        })
     }
 }
 
@@ -109,6 +130,24 @@ mod tests {
     use crate::initialize;
 
     use super::*;
+
+    #[test]
+    fn resource_id_to_and_from_string() {
+        let plain_text = "Hello, world!";
+        let mut hasher = Blake3Hasher::new();
+        hasher.update(plain_text.as_bytes());
+        let blake3 = hasher.finalize();
+
+        let id = ResourceId {
+            data_size: plain_text.len() as u64,
+            blake3: blake3.into(),
+        };
+
+        let id_str = id.to_string();
+        let id2 = id_str.parse::<ResourceId>().unwrap();
+
+        assert_eq!(id, id2);
+    }
 
     #[test]
     fn compute_id_test() {
@@ -127,7 +166,11 @@ mod tests {
         let id1 = ResourceId::compute(data_size, file_path).unwrap();
         assert_eq!(
             id1.blake3,
-            "172b4bf148e858b13dde0fc6613413bcb7552e5c4e5c45195ac6c80f20eb5ff5"
+            [
+                23, 43, 75, 241, 72, 232, 88, 177, 61, 222, 15, 198, 97, 52,
+                19, 188, 183, 85, 46, 92, 78, 92, 69, 25, 90, 198, 200, 15, 32,
+                235, 95, 245
+            ]
         );
         assert_eq!(id1.data_size, 128760);
 
@@ -135,7 +178,11 @@ mod tests {
         let id2 = ResourceId::compute_bytes(raw_bytes.as_slice()).unwrap();
         assert_eq!(
             id2.blake3,
-            "172b4bf148e858b13dde0fc6613413bcb7552e5c4e5c45195ac6c80f20eb5ff5"
+            [
+                23, 43, 75, 241, 72, 232, 88, 177, 61, 222, 15, 198, 97, 52,
+                19, 188, 183, 85, 46, 92, 78, 92, 69, 25, 90, 198, 200, 15, 32,
+                235, 95, 245
+            ]
         );
         assert_eq!(id2.data_size, 128760);
     }
@@ -144,11 +191,19 @@ mod tests {
     fn resource_id_order() {
         let id1 = ResourceId {
             data_size: 1,
-            blake3: "172b4bf148e858b13dde0fc6613413bcb7552e5c4e5c45195ac6c80f20eb5ff5".to_string(),
+            blake3: [
+                23, 43, 75, 241, 72, 232, 88, 177, 61, 222, 15, 198, 97, 52,
+                19, 188, 183, 85, 46, 92, 78, 92, 69, 25, 90, 198, 200, 15, 32,
+                235, 95, 245,
+            ],
         };
         let id2 = ResourceId {
             data_size: 2,
-            blake3: "172b4bf148e858b13dde0fc6613413bcb7552e5c4e5c45195ac6c80f20eb5ff5".to_string(),
+            blake3: [
+                23, 43, 75, 241, 72, 232, 88, 177, 61, 222, 15, 198, 97, 52,
+                19, 188, 183, 85, 46, 92, 78, 92, 69, 25, 90, 198, 200, 15, 32,
+                235, 95, 245,
+            ],
         };
 
         assert!(id1 < id2);

--- a/src/index.rs
+++ b/src/index.rs
@@ -360,10 +360,10 @@ impl ResourceIndex {
                     ));
                 }
                 Ok(new_entry) => {
-                    let id = new_entry.clone().id;
+                    let id = new_entry.id;
 
                     let mut added = HashMap::new();
-                    added.insert(path_buf.clone(), id.clone());
+                    added.insert(path_buf.clone(), id);
 
                     self.id2path.insert(id, path_buf.clone());
                     self.path2id.insert(path_buf, new_entry);
@@ -431,7 +431,7 @@ impl ResourceIndex {
                         self.forget_path(path, old_id).map(|mut update| {
                             update
                                 .added
-                                .insert(path_buf.clone(), new_entry.clone().id);
+                                .insert(path_buf.clone(), new_entry.id);
                             self.insert_entry(path_buf, new_entry);
 
                             update
@@ -472,7 +472,7 @@ impl ResourceIndex {
         let id = entry.clone().id;
 
         if let std::collections::hash_map::Entry::Vacant(e) =
-            self.id2path.entry(id.clone())
+            self.id2path.entry(id)
         {
             e.insert(path.clone());
         }
@@ -613,10 +613,16 @@ mod tests {
     const FILE_NAME_2: &str = "test2.txt";
     const FILE_NAME_3: &str = "test3.txt";
 
-    const BLAKE3_1: &str =
-        "40772e14b7665a8e7f09de41da09c4191acac132a598e4e363d076e19077057a";
-    const BLAKE3_2: &str =
-        "cae9b7f152d1262967980b77eb383b12796a8319bd154d36f75dc9f06cd2a69a";
+    const BLAKE3_1: [u8; 32] = [
+        64, 119, 46, 20, 183, 102, 90, 142, 127, 9, 222, 65, 218, 9, 196, 25,
+        26, 202, 193, 50, 165, 152, 228, 227, 99, 208, 118, 225, 144, 119, 5,
+        122,
+    ];
+    const BLAKE3_2: [u8; 32] = [
+        202, 233, 183, 241, 82, 209, 38, 41, 103, 152, 11, 119, 235, 56, 59,
+        18, 121, 106, 131, 25, 189, 21, 77, 54, 247, 93, 201, 240, 108, 210,
+        166, 154,
+    ];
 
     fn get_temp_dir() -> PathBuf {
         create_dir_at(std::env::temp_dir())
@@ -676,7 +682,7 @@ mod tests {
             assert_eq!(actual.id2path.len(), 1);
             assert!(actual.id2path.contains_key(&ResourceId {
                 data_size: FILE_SIZE_1,
-                blake3: BLAKE3_1.to_string(),
+                blake3: BLAKE3_1,
             }));
             assert_eq!(actual.size(), 1);
         })
@@ -730,11 +736,11 @@ mod tests {
             assert_eq!(actual.id2path.len(), 2);
             assert!(actual.id2path.contains_key(&ResourceId {
                 data_size: FILE_SIZE_1,
-                blake3: BLAKE3_1.to_string(),
+                blake3: BLAKE3_1,
             }));
             assert!(actual.id2path.contains_key(&ResourceId {
                 data_size: FILE_SIZE_2,
-                blake3: BLAKE3_2.to_string(),
+                blake3: BLAKE3_2,
             }));
             assert_eq!(actual.size(), 2);
             assert_eq!(update.deleted.len(), 0);
@@ -751,7 +757,7 @@ mod tests {
                     .clone(),
                 ResourceId {
                     data_size: FILE_SIZE_2,
-                    blake3: BLAKE3_2.to_string()
+                    blake3: BLAKE3_2
                 }
             )
         })
@@ -775,11 +781,11 @@ mod tests {
             assert_eq!(index.id2path.len(), 2);
             assert!(index.id2path.contains_key(&ResourceId {
                 data_size: FILE_SIZE_1,
-                blake3: BLAKE3_1.to_string(),
+                blake3: BLAKE3_1,
             }));
             assert!(index.id2path.contains_key(&ResourceId {
                 data_size: FILE_SIZE_2,
-                blake3: BLAKE3_2.to_string(),
+                blake3: BLAKE3_2,
             }));
             assert_eq!(index.size(), 2);
             assert_eq!(update.deleted.len(), 0);
@@ -795,7 +801,7 @@ mod tests {
                     .clone(),
                 ResourceId {
                     data_size: FILE_SIZE_2,
-                    blake3: BLAKE3_2.to_string()
+                    blake3: BLAKE3_2
                 }
             )
         })
@@ -814,7 +820,7 @@ mod tests {
                 &new_path,
                 ResourceId {
                     data_size: FILE_SIZE_2,
-                    blake3: BLAKE3_2.to_string(),
+                    blake3: BLAKE3_2,
                 },
             );
 
@@ -839,7 +845,7 @@ mod tests {
                     &file_path.clone(),
                     ResourceId {
                         data_size: FILE_SIZE_1,
-                        blake3: BLAKE3_1.to_string(),
+                        blake3: BLAKE3_1,
                     },
                 )
                 .expect("Should update index successfully");
@@ -853,7 +859,7 @@ mod tests {
 
             assert!(update.deleted.contains(&ResourceId {
                 data_size: FILE_SIZE_1,
-                blake3: BLAKE3_1.to_string(),
+                blake3: BLAKE3_1
             }))
         })
     }
@@ -895,7 +901,7 @@ mod tests {
             let mut actual = ResourceIndex::build(path.clone());
             let old_id = ResourceId {
                 data_size: 1,
-                blake3: BLAKE3_1.to_string(),
+                blake3: BLAKE3_1,
             };
             let result = actual
                 .update_one(&missing_path, old_id.clone())
@@ -907,7 +913,7 @@ mod tests {
                 result,
                 Some(ResourceId {
                     data_size: 1,
-                    blake3: BLAKE3_1.to_string(),
+                    blake3: BLAKE3_1,
                 })
             );
         })
@@ -921,7 +927,7 @@ mod tests {
             let mut actual = ResourceIndex::build(path.clone());
             let old_id = ResourceId {
                 data_size: 1,
-                blake3: BLAKE3_1.to_string(),
+                blake3: BLAKE3_1,
             };
             let result = actual
                 .update_one(&missing_path, old_id.clone())
@@ -933,7 +939,7 @@ mod tests {
                 result,
                 Some(ResourceId {
                     data_size: 1,
-                    blake3: BLAKE3_1.to_string(),
+                    blake3: BLAKE3_1
                 })
             );
         })
@@ -991,14 +997,14 @@ mod tests {
         let old1 = IndexEntry {
             id: ResourceId {
                 data_size: 1,
-                blake3: "2".to_string(),
+                blake3: BLAKE3_2,
             },
             modified: SystemTime::UNIX_EPOCH,
         };
         let old2 = IndexEntry {
             id: ResourceId {
                 data_size: 2,
-                blake3: "1".to_string(),
+                blake3: BLAKE3_1,
             },
             modified: SystemTime::UNIX_EPOCH,
         };
@@ -1006,14 +1012,14 @@ mod tests {
         let new1 = IndexEntry {
             id: ResourceId {
                 data_size: 1,
-                blake3: "1".to_string(),
+                blake3: BLAKE3_1,
             },
             modified: SystemTime::now(),
         };
         let new2 = IndexEntry {
             id: ResourceId {
                 data_size: 1,
-                blake3: "2".to_string(),
+                blake3: BLAKE3_2,
             },
             modified: SystemTime::now(),
         };

--- a/src/index.rs
+++ b/src/index.rs
@@ -680,10 +680,9 @@ mod tests {
             assert_eq!(actual.root, path.clone());
             assert_eq!(actual.path2id.len(), 1);
             assert_eq!(actual.id2path.len(), 1);
-            assert!(actual.id2path.contains_key(&ResourceId {
-                data_size: FILE_SIZE_1,
-                blake3: BLAKE3_1,
-            }));
+            assert!(actual
+                .id2path
+                .contains_key(&ResourceId { blake3: BLAKE3_1 }));
             assert_eq!(actual.size(), 1);
         })
     }
@@ -734,14 +733,12 @@ mod tests {
             assert_eq!(actual.root, path.clone());
             assert_eq!(actual.path2id.len(), 2);
             assert_eq!(actual.id2path.len(), 2);
-            assert!(actual.id2path.contains_key(&ResourceId {
-                data_size: FILE_SIZE_1,
-                blake3: BLAKE3_1,
-            }));
-            assert!(actual.id2path.contains_key(&ResourceId {
-                data_size: FILE_SIZE_2,
-                blake3: BLAKE3_2,
-            }));
+            assert!(actual
+                .id2path
+                .contains_key(&ResourceId { blake3: BLAKE3_1 }));
+            assert!(actual
+                .id2path
+                .contains_key(&ResourceId { blake3: BLAKE3_2 }));
             assert_eq!(actual.size(), 2);
             assert_eq!(update.deleted.len(), 0);
             assert_eq!(update.added.len(), 1);
@@ -755,10 +752,7 @@ mod tests {
                     .get(&added_key)
                     .expect("Key exists")
                     .clone(),
-                ResourceId {
-                    data_size: FILE_SIZE_2,
-                    blake3: BLAKE3_2
-                }
+                ResourceId { blake3: BLAKE3_2 }
             )
         })
     }
@@ -779,14 +773,12 @@ mod tests {
             assert_eq!(index.root, path.clone());
             assert_eq!(index.path2id.len(), 2);
             assert_eq!(index.id2path.len(), 2);
-            assert!(index.id2path.contains_key(&ResourceId {
-                data_size: FILE_SIZE_1,
-                blake3: BLAKE3_1,
-            }));
-            assert!(index.id2path.contains_key(&ResourceId {
-                data_size: FILE_SIZE_2,
-                blake3: BLAKE3_2,
-            }));
+            assert!(index
+                .id2path
+                .contains_key(&ResourceId { blake3: BLAKE3_1 }));
+            assert!(index
+                .id2path
+                .contains_key(&ResourceId { blake3: BLAKE3_2 }));
             assert_eq!(index.size(), 2);
             assert_eq!(update.deleted.len(), 0);
             assert_eq!(update.added.len(), 1);
@@ -799,10 +791,7 @@ mod tests {
                     .get(&added_key)
                     .expect("Key exists")
                     .clone(),
-                ResourceId {
-                    data_size: FILE_SIZE_2,
-                    blake3: BLAKE3_2
-                }
+                ResourceId { blake3: BLAKE3_2 }
             )
         })
     }
@@ -816,13 +805,8 @@ mod tests {
             let (_, new_path) =
                 create_file_at(path.clone(), Some(FILE_SIZE_2), None);
 
-            let update = index.update_one(
-                &new_path,
-                ResourceId {
-                    data_size: FILE_SIZE_2,
-                    blake3: BLAKE3_2,
-                },
-            );
+            let update =
+                index.update_one(&new_path, ResourceId { blake3: BLAKE3_2 });
 
             assert!(update.is_err())
         })
@@ -841,13 +825,7 @@ mod tests {
                 .expect("Should remove file successfully");
 
             let update = actual
-                .update_one(
-                    &file_path.clone(),
-                    ResourceId {
-                        data_size: FILE_SIZE_1,
-                        blake3: BLAKE3_1,
-                    },
-                )
+                .update_one(&file_path.clone(), ResourceId { blake3: BLAKE3_1 })
                 .expect("Should update index successfully");
 
             assert_eq!(actual.root, path.clone());
@@ -857,10 +835,9 @@ mod tests {
             assert_eq!(update.deleted.len(), 1);
             assert_eq!(update.added.len(), 0);
 
-            assert!(update.deleted.contains(&ResourceId {
-                data_size: FILE_SIZE_1,
-                blake3: BLAKE3_1
-            }))
+            assert!(update
+                .deleted
+                .contains(&ResourceId { blake3: BLAKE3_1 }))
         })
     }
 
@@ -899,23 +876,14 @@ mod tests {
             let mut missing_path = path.clone();
             missing_path.push("missing/directory");
             let mut actual = ResourceIndex::build(path.clone());
-            let old_id = ResourceId {
-                data_size: 1,
-                blake3: BLAKE3_1,
-            };
+            let old_id = ResourceId { blake3: BLAKE3_1 };
             let result = actual
                 .update_one(&missing_path, old_id.clone())
                 .map(|i| i.deleted.clone().take(&old_id))
                 .ok()
                 .flatten();
 
-            assert_eq!(
-                result,
-                Some(ResourceId {
-                    data_size: 1,
-                    blake3: BLAKE3_1,
-                })
-            );
+            assert_eq!(result, Some(ResourceId { blake3: BLAKE3_1 }));
         })
     }
 
@@ -925,23 +893,14 @@ mod tests {
             let mut missing_path = path.clone();
             missing_path.push("missing/directory");
             let mut actual = ResourceIndex::build(path.clone());
-            let old_id = ResourceId {
-                data_size: 1,
-                blake3: BLAKE3_1,
-            };
+            let old_id = ResourceId { blake3: BLAKE3_1 };
             let result = actual
                 .update_one(&missing_path, old_id.clone())
                 .map(|i| i.deleted.clone().take(&old_id))
                 .ok()
                 .flatten();
 
-            assert_eq!(
-                result,
-                Some(ResourceId {
-                    data_size: 1,
-                    blake3: BLAKE3_1
-                })
-            );
+            assert_eq!(result, Some(ResourceId { blake3: BLAKE3_1 }));
         })
     }
 
@@ -995,32 +954,20 @@ mod tests {
     #[test]
     fn index_entry_order() {
         let old1 = IndexEntry {
-            id: ResourceId {
-                data_size: 1,
-                blake3: BLAKE3_2,
-            },
+            id: ResourceId { blake3: BLAKE3_2 },
             modified: SystemTime::UNIX_EPOCH,
         };
         let old2 = IndexEntry {
-            id: ResourceId {
-                data_size: 2,
-                blake3: BLAKE3_1,
-            },
+            id: ResourceId { blake3: BLAKE3_1 },
             modified: SystemTime::UNIX_EPOCH,
         };
 
         let new1 = IndexEntry {
-            id: ResourceId {
-                data_size: 1,
-                blake3: BLAKE3_1,
-            },
+            id: ResourceId { blake3: BLAKE3_1 },
             modified: SystemTime::now(),
         };
         let new2 = IndexEntry {
-            id: ResourceId {
-                data_size: 1,
-                blake3: BLAKE3_2,
-            },
+            id: ResourceId { blake3: BLAKE3_2 },
             modified: SystemTime::now(),
         };
 
@@ -1032,7 +979,7 @@ mod tests {
         assert_ne!(new1, new2);
         assert_ne!(new1, old1);
 
-        assert!(old2 > old1);
+        assert!(old2 < old1);
         assert!(new1 > old1);
         assert!(new1 > old2);
         assert!(new2 > old1);

--- a/src/link.rs
+++ b/src/link.rs
@@ -105,13 +105,13 @@ impl Link {
         let bytes = self.url.as_str().as_bytes();
         temp_and_move(bytes, root.as_ref(), &id_string)?;
         //User defined properties
-        store_properties(&root, id.clone(), &self.prop)?;
+        store_properties(&root, id, &self.prop)?;
 
         // Generated data
         if let Ok(graph) = self.get_preview().await {
             log::debug!("Trying to save: {with_preview} with {graph:?}");
 
-            store_metadata(&root, id.clone(), &graph)?;
+            store_metadata(&root, id, &graph)?;
             if with_preview {
                 if let Some(preview_data) = graph.fetch_image().await {
                     self.save_preview(root, preview_data, &id)?;

--- a/src/link.rs
+++ b/src/link.rs
@@ -105,13 +105,13 @@ impl Link {
         let bytes = self.url.as_str().as_bytes();
         temp_and_move(bytes, root.as_ref(), &id_string)?;
         //User defined properties
-        store_properties(&root, id, &self.prop)?;
+        store_properties(&root, id.clone(), &self.prop)?;
 
         // Generated data
         if let Ok(graph) = self.get_preview().await {
             log::debug!("Trying to save: {with_preview} with {graph:?}");
 
-            store_metadata(&root, id, &graph)?;
+            store_metadata(&root, id.clone(), &graph)?;
             if with_preview {
                 if let Some(preview_data) = graph.fetch_image().await {
                     self.save_preview(root, preview_data, &id)?;

--- a/src/storage/meta.rs
+++ b/src/storage/meta.rs
@@ -80,15 +80,15 @@ mod tests {
         log::debug!("temporary root: {}", root.display());
 
         let id = ResourceId {
-            crc32: 0x342a3d4a,
             data_size: 1,
+            blake3: "abc".to_string(),
         };
 
         let mut meta = TestMetadata::new();
         meta.insert("abc".to_string(), "def".to_string());
         meta.insert("xyz".to_string(), "123".to_string());
 
-        store_metadata(root, id, &meta).unwrap();
+        store_metadata(root, id.clone(), &meta).unwrap();
 
         let bytes = load_raw_metadata(root, id).unwrap();
         let prop2: TestMetadata = serde_json::from_slice(&bytes).unwrap();

--- a/src/storage/meta.rs
+++ b/src/storage/meta.rs
@@ -81,14 +81,18 @@ mod tests {
 
         let id = ResourceId {
             data_size: 1,
-            blake3: "abc".to_string(),
+            blake3: [
+                23, 43, 75, 241, 72, 232, 88, 177, 61, 222, 15, 198, 97, 52,
+                19, 188, 183, 85, 46, 92, 78, 92, 69, 25, 90, 198, 200, 15, 32,
+                235, 95, 245,
+            ],
         };
 
         let mut meta = TestMetadata::new();
         meta.insert("abc".to_string(), "def".to_string());
         meta.insert("xyz".to_string(), "123".to_string());
 
-        store_metadata(root, id.clone(), &meta).unwrap();
+        store_metadata(root, id, &meta).unwrap();
 
         let bytes = load_raw_metadata(root, id).unwrap();
         let prop2: TestMetadata = serde_json::from_slice(&bytes).unwrap();

--- a/src/storage/meta.rs
+++ b/src/storage/meta.rs
@@ -80,7 +80,6 @@ mod tests {
         log::debug!("temporary root: {}", root.display());
 
         let id = ResourceId {
-            data_size: 1,
             blake3: [
                 23, 43, 75, 241, 72, 232, 88, 177, 61, 222, 15, 198, 97, 52,
                 19, 188, 183, 85, 46, 92, 78, 92, 69, 25, 90, 198, 200, 15, 32,

--- a/src/storage/prop.rs
+++ b/src/storage/prop.rs
@@ -82,14 +82,18 @@ mod tests {
 
         let id = ResourceId {
             data_size: 1,
-            blake3: "abc".to_string(),
+            blake3: [
+                23, 43, 75, 241, 72, 232, 88, 177, 61, 222, 15, 198, 97, 52,
+                19, 188, 183, 85, 46, 92, 78, 92, 69, 25, 90, 198, 200, 15, 32,
+                235, 95, 245,
+            ],
         };
 
         let mut prop = TestProperties::new();
         prop.insert("abc".to_string(), "def".to_string());
         prop.insert("xyz".to_string(), "123".to_string());
 
-        store_properties(root, id.clone(), &prop).unwrap();
+        store_properties(root, id, &prop).unwrap();
 
         let bytes = load_raw_properties(root, id).unwrap();
         let prop2: TestProperties = serde_json::from_slice(&bytes).unwrap();

--- a/src/storage/prop.rs
+++ b/src/storage/prop.rs
@@ -27,7 +27,8 @@ pub fn store_properties<
         let new_value = serde_json::to_value(properties).unwrap();
         match current_data {
             Some(old_data) => {
-                // Should not failed unless serialize failed which should never happen
+                // Should not failed unless serialize failed which should never
+                // happen
                 let old_value = serde_json::to_value(old_data).unwrap();
                 *current_data = Some(merge(old_value, new_value));
             }
@@ -80,15 +81,15 @@ mod tests {
         log::debug!("temporary root: {}", root.display());
 
         let id = ResourceId {
-            crc32: 0x342a3d4a,
             data_size: 1,
+            blake3: "abc".to_string(),
         };
 
         let mut prop = TestProperties::new();
         prop.insert("abc".to_string(), "def".to_string());
         prop.insert("xyz".to_string(), "123".to_string());
 
-        store_properties(root, id, &prop).unwrap();
+        store_properties(root, id.clone(), &prop).unwrap();
 
         let bytes = load_raw_properties(root, id).unwrap();
         let prop2: TestProperties = serde_json::from_slice(&bytes).unwrap();

--- a/src/storage/prop.rs
+++ b/src/storage/prop.rs
@@ -81,7 +81,6 @@ mod tests {
         log::debug!("temporary root: {}", root.display());
 
         let id = ResourceId {
-            data_size: 1,
             blake3: [
                 23, 43, 75, 241, 72, 232, 88, 177, 61, 222, 15, 198, 97, 52,
                 19, 188, 183, 85, 46, 92, 78, 92, 69, 25, 90, 198, 200, 15, 32,


### PR DESCRIPTION
### Description
This pull request updates the hashing method for the `ResourceId` struct, replacing `CRC32` with `BLAKE3` hash function.
Related Issue: #65
### Changes 
The changes include:
- Addition of benchmarks for the `ResourceId::compute_bytes` method using the `criterion` crate with the `html_reports` feature enabled. Run `cargo bench` to generate benchmarks in the `/target/criterion` folder
-  Removing collision handling as `BLAKE3` is a cryptographic hash function

> Refer to individual commit messages and bodies for detailed information