### PR TITLE
[Rustfmt] Remove Deprecated Tags `report_fixme` and `report_todo` from Configuration

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -7,8 +7,6 @@ single_line_if_else_max_width = 30
 
 force_explicit_abi = true
 
-report_todo = "Always"
-report_fixme = "Always"
 
 reorder_imports = true
 

--- a/src/atomic/file.rs
+++ b/src/atomic/file.rs
@@ -52,7 +52,8 @@ pub struct ReadOnlyFile {
     pub path: PathBuf,
 }
 
-/// This struct is the only way to read the file. Both path and version are private
+/// This struct is the only way to read the file. Both path and version are
+/// private
 impl ReadOnlyFile {
     /// Open the underlying file, which can be read from but not written to.
     /// May return `Ok(None)`, which means that no version

--- a/src/atomic/mod.rs
+++ b/src/atomic/mod.rs
@@ -79,7 +79,8 @@ mod tests {
                 let current = file.load().unwrap();
                 let content = format!("Content from thread {i}!");
                 (&temp).write_all(content.as_bytes()).unwrap();
-                // In case slow computer ensure each thread are running in the same time
+                // In case slow computer ensure each thread are running in the
+                // same time
                 std::thread::sleep(std::time::Duration::from_millis(300));
                 file.compare_and_swap(&current, temp)
             });
@@ -108,7 +109,8 @@ mod tests {
         let shared_file = std::sync::Arc::new(AtomicFile::new(root).unwrap());
         let thread_number = 10;
         assert!(thread_number > 3);
-        // Need to have less than 255 thread to store thread number as byte directly
+        // Need to have less than 255 thread to store thread number as byte
+        // directly
         assert!(thread_number < 256);
         let mut handles = Vec::with_capacity(thread_number);
         for i in 0..thread_number {

--- a/src/index.rs
+++ b/src/index.rs
@@ -82,7 +82,10 @@ impl ResourceIndex {
         };
 
         // We should not return early in case of missing files
-        for line in BufReader::new(file).lines().flatten() {
+        let lines = BufReader::new(file).lines();
+        for line in lines {
+            let line = line?;
+
             let mut parts = line.split(' ');
 
             let modified = {

--- a/src/storage/prop.rs
+++ b/src/storage/prop.rs
@@ -27,7 +27,8 @@ pub fn store_properties<
         let new_value = serde_json::to_value(properties).unwrap();
         match current_data {
             Some(old_data) => {
-                // Should not failed unless serialize failed which should never happen
+                // Should not failed unless serialize failed which should never
+                // happen
                 let old_value = serde_json::to_value(old_data).unwrap();
                 *current_data = Some(merge(old_value, new_value));
             }


### PR DESCRIPTION
This pull request removes the deprecated tags `report_fixme` and `report_todo` from the `rustfmt.toml` configuration file.

For reference:
- [Planned removal of `report_fixme`](https://github.com/rust-lang/rustfmt/issues/5102)
- [Planned removal of `report_todo`](https://github.com/rust-lang/rustfmt/issues/5101)