### PR TITLE
Refactor `src/index.rs` and Enhance Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 **/app_id
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ env_logger = "0.9.0"
 lazy_static = "1.4.0"
 canonical-path = "2.0.2"
 pathdiff = "0.2.1"
-image = "0.24.2"
+image = "0.25"
 pdfium-render = { git = "https://github.com/ajrcarey/pdfium-render", rev = "d2559c1", features = [
     "thread_safe",
     "sync",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ pdfium-render = { git = "https://github.com/ajrcarey/pdfium-render", rev = "d255
 libloading = "0.7.3"
 serde_json = "1.0.82"
 serde = { version = "1.0.138", features = ["derive"] }
+serde_with = "3.6.1"
 url = { version = "2.2.2", features = ["serde"] }
 reqwest = "0.11.11"
 scraper = "0.13.0"

--- a/src/index.rs
+++ b/src/index.rs
@@ -593,6 +593,9 @@ fn discover_files<P: AsRef<Path>>(root_path: P) -> HashMap<PathBuf, DirEntry> {
     discovered_files
 }
 
+/// Scans a single file entry and extracts its metadata to create an index entry
+///
+/// Returns an error if the path is a directory or if the file is empty
 fn scan_entry(path: &Path, metadata: Metadata) -> Result<IndexEntry> {
     if metadata.is_dir() {
         return Err(ArklibError::Path("Path is expected to be a file".into()));
@@ -600,10 +603,7 @@ fn scan_entry(path: &Path, metadata: Metadata) -> Result<IndexEntry> {
 
     let size = metadata.len();
     if size == 0 {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            "Empty resource",
-        ))?;
+        return Err(ArklibError::Path("Empty file".into()));
     }
 
     let id = ResourceId::compute(size, path)?;
@@ -612,6 +612,9 @@ fn scan_entry(path: &Path, metadata: Metadata) -> Result<IndexEntry> {
     Ok(IndexEntry { id, modified })
 }
 
+/// Scans multiple file entries and creates index entries for each one
+///
+/// Returns a hashmap of file paths to their corresponding index entries
 fn scan_entries(
     entries: HashMap<PathBuf, DirEntry>,
 ) -> HashMap<PathBuf, IndexEntry> {

--- a/src/index.rs
+++ b/src/index.rs
@@ -609,7 +609,7 @@ impl ResourceIndex {
                 "Any collision must involve at least 2 resources"
             );
             *collisions -= 1;
-            if *collisions <= 1 {
+            if *collisions == 1 {
                 self.collisions.remove(&old_id);
             }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -440,14 +440,14 @@ impl ResourceIndex {
         }
 
         // new resource exists by the path
-        return self.forget_path(path, old_id).map(|mut update| {
+        self.forget_path(path, old_id).map(|mut update| {
             update
                 .added
                 .insert(path_buf.clone(), new_entry.id);
             self.insert_entry(path_buf, new_entry);
 
             update
-        });
+        })
     }
 
     /// Inserts an entry into the index, updating associated data structures

--- a/src/index.rs
+++ b/src/index.rs
@@ -1188,6 +1188,29 @@ mod tests {
     }
 
     #[test]
+    fn test_index_hidden_directory() {
+        let temp_dir = TempDir::new(".arklib_test")
+            .expect("Failed to create temporary directory");
+        let temp_dir = temp_dir.into_path();
+
+        create_file_at(temp_dir.to_owned(), Some(FILE_SIZE_1), None);
+        let actual = ResourceIndex::build(temp_dir.to_owned());
+
+        let canonical_path = fs::canonicalize(temp_dir.clone())
+            .expect("CanonicalPathBuf should be fine");
+
+        assert_eq!(actual.root, canonical_path.to_owned());
+        assert_eq!(actual.path2id.len(), 1);
+        assert_eq!(actual.id2path.len(), 1);
+        assert!(actual.id2path.contains_key(&ResourceId {
+            data_size: FILE_SIZE_1,
+            crc32: CRC32_1,
+        }));
+        assert_eq!(actual.collisions.len(), 0);
+        assert_eq!(actual.size(), 1);
+    }
+
+    #[test]
     fn index_entry_order() {
         let old1 = IndexEntry {
             id: ResourceId {

--- a/src/index.rs
+++ b/src/index.rs
@@ -130,6 +130,7 @@ impl ResourceIndex {
     /// persisting the new index version, use [`ResourceIndex::provide()`] method.
     pub fn load<P: AsRef<Path>>(root_path: P) -> Result<Self> {
         let root_path: PathBuf = root_path.as_ref().to_owned();
+        let root_path = fs::canonicalize(&root_path)?;
 
         let index_path: PathBuf = root_path.join(ARK_FOLDER).join(INDEX_PATH);
         log::info!("Loading the index from file {}", index_path.display());

--- a/src/index.rs
+++ b/src/index.rs
@@ -62,20 +62,26 @@ impl ResourceIndex {
         self.path2id.len()
     }
 
+    /// Builds a new resource index from scratch using the root path
+    ///
+    /// This function recursively scans the directory structure starting from
+    /// the root path, constructs index entries for each resource found, and
+    /// populates the resource index
     pub fn build<P: AsRef<Path>>(root_path: P) -> Self {
-        log::info!("Building the index from scratch");
-        let root_path: PathBuf = root_path.as_ref().to_owned();
+        let root_path = root_path.as_ref().to_owned();
+        log::info!(
+            "Building the index from scratch for directory: {}",
+            &root_path.display()
+        );
 
         let entries = discover_paths(&root_path);
         let entries = scan_entries(entries);
-
         let mut index = ResourceIndex {
             id2path: HashMap::new(),
             path2id: HashMap::new(),
             collisions: HashMap::new(),
             root: root_path,
         };
-
         for (path, entry) in entries {
             index.insert_entry(path, entry);
         }

--- a/src/index.rs
+++ b/src/index.rs
@@ -586,6 +586,7 @@ fn discover_files<P: AsRef<Path>>(root_path: P) -> HashMap<PathBuf, DirEntry> {
 
     let mut discovered_files = HashMap::new();
     let walker = WalkDir::new(root_path)
+        .min_depth(1)
         .into_iter()
         .filter_entry(|entry| {
             // skip hidden files and directories

--- a/src/index.rs
+++ b/src/index.rs
@@ -86,7 +86,9 @@ impl ResourceIndex {
     /// the root path, constructs index entries for each resource found, and
     /// populates the resource index
     pub fn build<P: AsRef<Path>>(root_path: P) -> Self {
-        let root_path = root_path.as_ref().to_owned();
+        let root_path = fs::canonicalize(root_path.as_ref())
+            .expect("Failed to canonicalize root path");
+
         log::info!(
             "Building the index from scratch for directory: {}",
             &root_path.display()
@@ -767,7 +769,10 @@ mod tests {
         create_file_at(temp_dir.to_owned(), Some(FILE_SIZE_1), None);
         let actual = ResourceIndex::build(temp_dir.to_owned());
 
-        assert_eq!(actual.root, temp_dir.to_owned());
+        let canonical_path = fs::canonicalize(temp_dir.clone())
+            .expect("CanonicalPathBuf should be fine");
+
+        assert_eq!(actual.root, canonical_path.to_owned());
         assert_eq!(actual.path2id.len(), 1);
         assert_eq!(actual.id2path.len(), 1);
         assert!(actual.id2path.contains_key(&ResourceId {
@@ -788,7 +793,9 @@ mod tests {
         create_file_at(path.to_owned(), Some(FILE_SIZE_1), None);
         let actual = ResourceIndex::build(path.to_owned());
 
-        assert_eq!(actual.root, path.to_owned());
+        let canonical_path = fs::canonicalize(path.clone())
+            .expect("CanonicalPathBuf should be fine");
+        assert_eq!(actual.root, canonical_path.to_owned());
         assert_eq!(actual.path2id.len(), 2);
         assert_eq!(actual.id2path.len(), 1);
         assert!(actual.id2path.contains_key(&ResourceId {
@@ -844,7 +851,9 @@ mod tests {
             .update_all()
             .expect("Should update index correctly");
 
-        assert_eq!(actual.root, path.to_owned());
+        let canonical_path = fs::canonicalize(path.clone())
+            .expect("CanonicalPathBuf should be fine");
+        assert_eq!(actual.root, canonical_path);
         assert_eq!(actual.path2id.len(), 2);
         assert_eq!(actual.id2path.len(), 2);
         assert!(actual.id2path.contains_key(&ResourceId {
@@ -911,7 +920,9 @@ mod tests {
             .index_new(&new_path)
             .expect("Should update index correctly");
 
-        assert_eq!(index.root, path.clone());
+        let canonical_path = fs::canonicalize(path.clone())
+            .expect("CanonicalPathBuf should be fine");
+        assert_eq!(index.root, canonical_path.clone());
         assert_eq!(index.path2id.len(), 2);
         assert_eq!(index.id2path.len(), 2);
         assert!(index.id2path.contains_key(&ResourceId {
@@ -986,7 +997,9 @@ mod tests {
             )
             .expect("Should update index successfully");
 
-        assert_eq!(actual.root, path.clone());
+        let canonical_path = fs::canonicalize(path.clone())
+            .expect("CanonicalPathBuf should be fine");
+        assert_eq!(actual.root, canonical_path);
         assert_eq!(actual.path2id.len(), 0);
         assert_eq!(actual.id2path.len(), 0);
         assert_eq!(actual.collisions.len(), 0);
@@ -1094,7 +1107,9 @@ mod tests {
         create_file_at(path.clone(), Some(0), None);
         let actual = ResourceIndex::build(path.clone());
 
-        assert_eq!(actual.root, path.clone());
+        let canonical_path = fs::canonicalize(path.clone())
+            .expect("CanonicalPathBuf should be fine");
+        assert_eq!(actual.root, canonical_path);
         assert_eq!(actual.path2id.len(), 0);
         assert_eq!(actual.id2path.len(), 0);
         assert_eq!(actual.collisions.len(), 0);
@@ -1109,7 +1124,9 @@ mod tests {
         create_file_at(path.clone(), Some(FILE_SIZE_1), Some(".hidden"));
         let actual = ResourceIndex::build(path.clone());
 
-        assert_eq!(actual.root, path.clone());
+        let canonical_path = fs::canonicalize(path.clone())
+            .expect("CanonicalPathBuf should be fine");
+        assert_eq!(actual.root, canonical_path);
         assert_eq!(actual.path2id.len(), 0);
         assert_eq!(actual.id2path.len(), 0);
         assert_eq!(actual.collisions.len(), 0);
@@ -1125,7 +1142,9 @@ mod tests {
 
         let actual = ResourceIndex::build(path.clone());
 
-        assert_eq!(actual.root, path.clone());
+        let canonical_path = fs::canonicalize(path.clone())
+            .expect("CanonicalPathBuf should be fine");
+        assert_eq!(actual.root, canonical_path);
         assert_eq!(actual.path2id.len(), 0);
         assert_eq!(actual.id2path.len(), 0);
         assert_eq!(actual.collisions.len(), 0);

--- a/src/index.rs
+++ b/src/index.rs
@@ -47,9 +47,9 @@ pub struct IndexEntry {
 pub struct ResourceIndex {
     /// A mapping of resource IDs to their corresponding file paths
     #[serde_as(as = "Vec<(_, _)>")]
-    pub id2path: HashMap<ResourceId, PathBuf>,
+    id2path: HashMap<ResourceId, PathBuf>,
     /// A mapping of file paths to their corresponding index entries
-    pub path2id: HashMap<PathBuf, IndexEntry>,
+    path2id: HashMap<PathBuf, IndexEntry>,
     /// A mapping of resource IDs to the number of collisions they have
     pub collisions: HashMap<ResourceId, usize>,
     /// The root path of the index
@@ -76,8 +76,13 @@ impl ResourceIndex {
     /// Returns the number of entries in the index
     ///
     /// Note that the amount of resource can be lower in presence of collisions
-    pub fn size(&self) -> usize {
+    pub fn count_files(&self) -> usize {
         self.path2id.len()
+    }
+
+    /// Returns the number of resources in the index
+    pub fn count_resources(&self) -> usize {
+        self.id2path.len()
     }
 
     /// Builds a new resource index from scratch using the root path
@@ -781,7 +786,7 @@ mod tests {
             crc32: CRC32_1,
         }));
         assert_eq!(actual.collisions.len(), 0);
-        assert_eq!(actual.size(), 1);
+        assert_eq!(actual.count_files(), 1);
     }
 
     #[test]
@@ -804,7 +809,7 @@ mod tests {
             crc32: CRC32_1,
         }));
         assert_eq!(actual.collisions.len(), 1);
-        assert_eq!(actual.size(), 2);
+        assert_eq!(actual.count_files(), 2);
     }
 
     #[test]
@@ -818,7 +823,7 @@ mod tests {
         let mut actual = ResourceIndex::build(path.to_owned());
 
         assert_eq!(actual.collisions.len(), 0);
-        assert_eq!(actual.size(), 2);
+        assert_eq!(actual.count_files(), 2);
 
         // rename test2.txt to test3.txt
         let mut name_from = path.to_owned();
@@ -833,7 +838,7 @@ mod tests {
             .expect("Should update index correctly");
 
         assert_eq!(actual.collisions.len(), 0);
-        assert_eq!(actual.size(), 2);
+        assert_eq!(actual.count_files(), 2);
         assert_eq!(update.deleted.len(), 1);
         assert_eq!(update.added.len(), 1);
     }
@@ -866,7 +871,7 @@ mod tests {
             crc32: CRC32_2,
         }));
         assert_eq!(actual.collisions.len(), 0);
-        assert_eq!(actual.size(), 2);
+        assert_eq!(actual.count_files(), 2);
         assert_eq!(update.deleted.len(), 0);
         assert_eq!(update.added.len(), 1);
 
@@ -935,7 +940,7 @@ mod tests {
             crc32: CRC32_2,
         }));
         assert_eq!(index.collisions.len(), 0);
-        assert_eq!(index.size(), 2);
+        assert_eq!(index.count_files(), 2);
         assert_eq!(update.deleted.len(), 0);
         assert_eq!(update.added.len(), 1);
 
@@ -1004,7 +1009,7 @@ mod tests {
         assert_eq!(actual.path2id.len(), 0);
         assert_eq!(actual.id2path.len(), 0);
         assert_eq!(actual.collisions.len(), 0);
-        assert_eq!(actual.size(), 0);
+        assert_eq!(actual.count_files(), 0);
         assert_eq!(update.deleted.len(), 1);
         assert_eq!(update.added.len(), 0);
 
@@ -1026,7 +1031,7 @@ mod tests {
         let mut actual = ResourceIndex::build(path.clone());
 
         assert_eq!(actual.collisions.len(), 0);
-        assert_eq!(actual.size(), 2);
+        assert_eq!(actual.count_files(), 2);
         #[cfg(target_family = "unix")]
         file.set_permissions(Permissions::from_mode(0o222))
             .expect("Should be fine");
@@ -1036,7 +1041,7 @@ mod tests {
             .expect("Should update index correctly");
 
         assert_eq!(actual.collisions.len(), 0);
-        assert_eq!(actual.size(), 2);
+        assert_eq!(actual.count_files(), 2);
         assert_eq!(update.deleted.len(), 0);
         assert_eq!(update.added.len(), 0);
     }
@@ -1208,7 +1213,7 @@ mod tests {
             crc32: CRC32_1,
         }));
         assert_eq!(actual.collisions.len(), 0);
-        assert_eq!(actual.size(), 1);
+        assert_eq!(actual.count_files(), 1);
     }
 
     #[test]

--- a/src/index.rs
+++ b/src/index.rs
@@ -655,12 +655,11 @@ mod tests {
     use super::fs;
     use crate::id::ResourceId;
     use crate::index::{discover_files, IndexEntry};
-    use crate::initialize;
     use crate::ResourceIndex;
     use std::fs::File;
-    #[cfg(target_os = "linux")]
+    #[cfg(target_family = "unix")]
     use std::fs::Permissions;
-    #[cfg(target_os = "linux")]
+    #[cfg(target_family = "unix")]
     use std::os::unix::fs::PermissionsExt;
     use tempdir::TempDir;
 
@@ -995,7 +994,7 @@ mod tests {
 
         assert_eq!(actual.collisions.len(), 0);
         assert_eq!(actual.size(), 2);
-        #[cfg(target_os = "linux")]
+        #[cfg(target_family = "unix")]
         file.set_permissions(Permissions::from_mode(0o222))
             .expect("Should be fine");
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -38,12 +38,6 @@ pub struct IndexEntry {
 /// paths to index entries, which are simply resource IDs with modification
 /// timestamps.
 ///
-/// The paths stored in the mappings are not absolute paths, but are relative
-/// to the "root". See methods `TODO` and `TODO` in the API, which can provide
-/// the end users with absolute/canonical(TODO) paths for the convenince.
-/// Otherwise, the end user is responsible for managing the working dir
-/// and relative paths resolution.
-///
 /// Additionally, it keeps track of collisions that occur during
 /// indexing using non-cryptographic hash functions.
 #[serde_as]

--- a/src/storage/meta.rs
+++ b/src/storage/meta.rs
@@ -1,7 +1,6 @@
 use crate::atomic::{modify_json, AtomicFile};
 use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
-use std::io::Read;
 use std::path::Path;
 
 use crate::id::ResourceId;
@@ -35,64 +34,4 @@ pub fn store_metadata<
         }
     })?;
     Ok(())
-}
-
-/// The file must exist if this method is called
-#[allow(dead_code)]
-pub fn load_raw_metadata<P: AsRef<Path>>(
-    root: P,
-    id: ResourceId,
-) -> Result<Vec<u8>> {
-    let storage = root
-        .as_ref()
-        .join(ARK_FOLDER)
-        .join(METADATA_STORAGE_FOLDER)
-        .join(id.to_string());
-    let file = AtomicFile::new(storage)?;
-    let read_file = file.load()?;
-    if let Some(mut real_file) = read_file.open()? {
-        let mut content = vec![];
-        real_file.read_to_end(&mut content)?;
-        Ok(content)
-    } else {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "File not found",
-        ))?
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::initialize;
-
-    use super::*;
-    use tempdir::TempDir;
-
-    use std::collections::HashMap;
-    type TestMetadata = HashMap<String, String>;
-
-    #[test]
-    fn test_store_and_load() {
-        initialize();
-
-        let dir = TempDir::new("arklib_test").unwrap();
-        let root = dir.path();
-        log::debug!("temporary root: {}", root.display());
-
-        let id = ResourceId {
-            crc32: 0x342a3d4a,
-            data_size: 1,
-        };
-
-        let mut meta = TestMetadata::new();
-        meta.insert("abc".to_string(), "def".to_string());
-        meta.insert("xyz".to_string(), "123".to_string());
-
-        store_metadata(root, id, &meta).unwrap();
-
-        let bytes = load_raw_metadata(root, id).unwrap();
-        let prop2: TestMetadata = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(meta, prop2);
-    }
 }

--- a/src/storage/meta.rs
+++ b/src/storage/meta.rs
@@ -38,6 +38,7 @@ pub fn store_metadata<
 }
 
 /// The file must exist if this method is called
+#[allow(dead_code)]
 pub fn load_raw_metadata<P: AsRef<Path>>(
     root: P,
     id: ResourceId,


### PR DESCRIPTION
## Description
This PR focuses on refactoring the `src/index.rs` file. 
## Changes
The changes primarily include:
- Define constants at the beginning of the file
- Add doc comments for structs, fields, and methods 
- Use `serde::{Deserialize, Serialize}` for loading and storing of the index file
- Rename the `discover_paths` function to `discover_files` 
- Refactor certain parts of the code to improve readability, including reducing indentation where possible
- Add a new test to ensure that only canonical paths are present in the index
- Use of `TempDir` for testing 
- Updating platform conditions for improved cross-compatibility (`#[cfg(target_family = "unix")]`)

## Edit
Fixes #89 with 633335ab42a603fe646b1bfe7b687a271b7ab9b3
