### PR TITLE
Generic Resource Identifiers with `ResourceIdTrait`

### DIFF
--- a/benches/compute_bytes_benchmark.rs
+++ b/benches/compute_bytes_benchmark.rs
@@ -1,5 +1,4 @@
-use arklib::resource::ResourceId;
-use arklib::resource::ResourceIdTrait;
+use arklib::resource::{ResourceId, ResourceIdTrait};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::prelude::*;
 use std::fs;

--- a/benches/compute_bytes_benchmark.rs
+++ b/benches/compute_bytes_benchmark.rs
@@ -1,4 +1,5 @@
-use arklib::id::ResourceId;
+use arklib::resource::ResourceId;
+use arklib::resource::ResourceIdTrait;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::prelude::*;
 use std::fs;

--- a/src/index.rs
+++ b/src/index.rs
@@ -14,13 +14,13 @@ use std::time::UNIX_EPOCH;
 use std::time::{Duration, SystemTime};
 use walkdir::{DirEntry, WalkDir};
 
-use crate::{id::ResourceId, ArklibError, Result, ARK_FOLDER, INDEX_PATH};
+use crate::{
+    resource::ResourceId, ArklibError, Result, ARK_FOLDER, INDEX_PATH,
+};
 
 pub const RESOURCE_UPDATED_THRESHOLD: Duration = Duration::from_millis(1);
 pub type Paths = HashSet<PathBuf>;
-use crate::resource::ResourceId;
 use crate::resource::ResourceIdTrait;
-use crate::{ArklibError, Result, ARK_FOLDER, INDEX_PATH};
 
 /// IndexEntry represents a [`ResourceId`] and the time it was last modified
 #[derive(
@@ -844,7 +844,7 @@ mod tests {
         assert_eq!(actual.id2path.len(), 1);
         assert!(actual.id2path.contains_key(&ResourceId {
             data_size: FILE_SIZE_1,
-            crc32: CRC32_1,
+            hash: CRC32_1,
         }));
         assert_eq!(actual.collisions.len(), 0);
         assert_eq!(actual.count_files(), 1);
@@ -867,7 +867,7 @@ mod tests {
         assert_eq!(actual.id2path.len(), 1);
         assert!(actual.id2path.contains_key(&ResourceId {
             data_size: FILE_SIZE_1,
-            crc32: CRC32_1,
+            hash: CRC32_1,
         }));
         assert_eq!(actual.collisions.len(), 1);
         assert_eq!(actual.count_files(), 2);
@@ -925,11 +925,11 @@ mod tests {
         assert_eq!(actual.id2path.len(), 2);
         assert!(actual.id2path.contains_key(&ResourceId {
             data_size: FILE_SIZE_1,
-            crc32: CRC32_1,
+            hash: CRC32_1,
         }));
         assert!(actual.id2path.contains_key(&ResourceId {
             data_size: FILE_SIZE_2,
-            crc32: CRC32_2,
+            hash: CRC32_2,
         }));
         assert_eq!(actual.collisions.len(), 0);
         assert_eq!(actual.count_files(), 2);
@@ -947,7 +947,7 @@ mod tests {
                 .clone(),
             ResourceId {
                 data_size: FILE_SIZE_2,
-                crc32: CRC32_2
+                hash: CRC32_2
             }
         )
     }
@@ -994,11 +994,11 @@ mod tests {
         assert_eq!(index.id2path.len(), 2);
         assert!(index.id2path.contains_key(&ResourceId {
             data_size: FILE_SIZE_1,
-            crc32: CRC32_1,
+            hash: CRC32_1,
         }));
         assert!(index.id2path.contains_key(&ResourceId {
             data_size: FILE_SIZE_2,
-            crc32: CRC32_2,
+            hash: CRC32_2,
         }));
         assert_eq!(index.collisions.len(), 0);
         assert_eq!(index.count_files(), 2);
@@ -1016,7 +1016,7 @@ mod tests {
                 .clone(),
             ResourceId {
                 data_size: FILE_SIZE_2,
-                crc32: CRC32_2
+                hash: CRC32_2
             }
         )
     }
@@ -1035,7 +1035,7 @@ mod tests {
             &new_path,
             ResourceId {
                 data_size: FILE_SIZE_2,
-                crc32: CRC32_2,
+                hash: CRC32_2,
             },
         );
 
@@ -1059,7 +1059,7 @@ mod tests {
                 &file_path.clone(),
                 ResourceId {
                     data_size: FILE_SIZE_1,
-                    crc32: CRC32_1,
+                    hash: CRC32_1,
                 },
             )
             .expect("Should update index successfully");
@@ -1076,7 +1076,7 @@ mod tests {
 
         assert!(update.deleted.contains(&ResourceId {
             data_size: FILE_SIZE_1,
-            crc32: CRC32_1
+            hash: CRC32_1
         }))
     }
 
@@ -1120,7 +1120,7 @@ mod tests {
         let mut actual = ResourceIndex::build(path.clone());
         let old_id = ResourceId {
             data_size: 1,
-            crc32: 2,
+            hash: 2,
         };
         let result = actual
             .update_one(&missing_path, old_id)
@@ -1132,7 +1132,7 @@ mod tests {
             result,
             Some(ResourceId {
                 data_size: 1,
-                crc32: 2,
+                hash: 2,
             })
         );
     }
@@ -1148,7 +1148,7 @@ mod tests {
         let mut actual = ResourceIndex::build(path.clone());
         let old_id = ResourceId {
             data_size: 1,
-            crc32: 2,
+            hash: 2,
         };
         let result = actual
             .update_one(&missing_path, old_id)
@@ -1160,7 +1160,7 @@ mod tests {
             result,
             Some(ResourceId {
                 data_size: 1,
-                crc32: 2,
+                hash: 2,
             })
         )
     }
@@ -1271,7 +1271,7 @@ mod tests {
         assert_eq!(actual.id2path.len(), 1);
         assert!(actual.id2path.contains_key(&ResourceId {
             data_size: FILE_SIZE_1,
-            crc32: CRC32_1,
+            hash: CRC32_1,
         }));
         assert_eq!(actual.collisions.len(), 0);
         assert_eq!(actual.count_files(), 1);
@@ -1282,14 +1282,14 @@ mod tests {
         let old1 = IndexEntry {
             id: ResourceId {
                 data_size: 1,
-                crc32: 2,
+                hash: 2,
             },
             modified: SystemTime::UNIX_EPOCH,
         };
         let old2 = IndexEntry {
             id: ResourceId {
                 data_size: 2,
-                crc32: 1,
+                hash: 1,
             },
             modified: SystemTime::UNIX_EPOCH,
         };
@@ -1297,14 +1297,14 @@ mod tests {
         let new1 = IndexEntry {
             id: ResourceId {
                 data_size: 1,
-                crc32: 1,
+                hash: 1,
             },
             modified: SystemTime::now(),
         };
         let new2 = IndexEntry {
             id: ResourceId {
                 data_size: 1,
-                crc32: 2,
+                hash: 2,
             },
             modified: SystemTime::now(),
         };

--- a/src/index.rs
+++ b/src/index.rs
@@ -18,6 +18,9 @@ use crate::{id::ResourceId, ArklibError, Result, ARK_FOLDER, INDEX_PATH};
 
 pub const RESOURCE_UPDATED_THRESHOLD: Duration = Duration::from_millis(1);
 pub type Paths = HashSet<PathBuf>;
+use crate::resource::ResourceId;
+use crate::resource::ResourceIdTrait;
+use crate::{ArklibError, Result, ARK_FOLDER, INDEX_PATH};
 
 /// IndexEntry represents a [`ResourceId`] and the time it was last modified
 #[derive(
@@ -750,8 +753,9 @@ fn scan_entries(
 #[cfg(test)]
 mod tests {
     use super::fs;
-    use crate::id::ResourceId;
     use crate::index::{discover_files, IndexEntry};
+    use crate::initialize;
+    use crate::resource::ResourceId;
     use crate::ResourceIndex;
     use std::fs::File;
     #[cfg(target_family = "unix")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,11 @@ pub mod errors;
 pub use errors::{ArklibError, Result};
 
 pub mod app_id;
-pub mod id;
 pub mod index;
 
 pub mod link;
 pub mod pdf;
+pub mod resource;
 
 mod atomic;
 mod storage;

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,5 +1,4 @@
-use crate::resource::ResourceId;
-use crate::resource::ResourceIdTrait;
+use crate::resource::{ResourceId, ResourceIdTrait};
 use crate::storage::meta::store_metadata;
 use crate::storage::prop::store_properties;
 use crate::{

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,4 +1,5 @@
-use crate::id::ResourceId;
+use crate::resource::ResourceId;
+use crate::resource::ResourceIdTrait;
 use crate::storage::meta::store_metadata;
 use crate::storage::prop::store_properties;
 use crate::{

--- a/src/resource/crc32.rs
+++ b/src/resource/crc32.rs
@@ -57,10 +57,6 @@ impl FromStr for ResourceId {
 impl ResourceIdTrait<'_> for ResourceId {
     type HashType = u32;
 
-    fn get_hash(&self) -> Self::HashType {
-        self.hash
-    }
-
     fn compute<P: AsRef<Path>>(data_size: u64, file_path: P) -> Result<Self> {
         log::trace!(
             "[compute] file {} with size {} mb",
@@ -140,12 +136,12 @@ mod tests {
             .len();
 
         let id1 = ResourceId::compute(data_size, file_path).unwrap();
-        assert_eq!(id1.get_hash(), 0x342a3d4a);
+        assert_eq!(id1.hash, 0x342a3d4a);
         assert_eq!(id1.data_size, 128760);
 
         let raw_bytes = fs::read(file_path).unwrap();
         let id2 = ResourceId::compute_bytes(raw_bytes.as_slice()).unwrap();
-        assert_eq!(id2.get_hash(), 0x342a3d4a);
+        assert_eq!(id2.hash, 0x342a3d4a);
         assert_eq!(id2.data_size, 128760);
     }
 

--- a/src/resource/crc32.rs
+++ b/src/resource/crc32.rs
@@ -16,6 +16,9 @@ const KILOBYTE: u64 = 1024;
 const MEGABYTE: u64 = 1024 * KILOBYTE;
 const BUFFER_CAPACITY: usize = 512 * KILOBYTE as usize;
 
+/// Represents a resource identifier using the CRC32 algorithm.
+///
+/// Uses `crc32fast` crate to compute the hash value.
 #[derive(
     Eq,
     Ord,

--- a/src/resource/crc32.rs
+++ b/src/resource/crc32.rs
@@ -30,12 +30,12 @@ const BUFFER_CAPACITY: usize = 512 * KILOBYTE as usize;
 )]
 pub struct ResourceIdCrc32 {
     pub data_size: u64,
-    pub crc32: u32,
+    pub hash: u32,
 }
 
 impl Display for ResourceIdCrc32 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}-{}", self.data_size, self.crc32)
+        write!(f, "{}-{}", self.data_size, self.hash)
     }
 }
 
@@ -45,9 +45,9 @@ impl FromStr for ResourceIdCrc32 {
     fn from_str(s: &str) -> Result<Self> {
         let (l, r) = s.split_once('-').ok_or(ArklibError::Parse)?;
         let data_size: u64 = l.parse().map_err(|_| ArklibError::Parse)?;
-        let crc32: u32 = r.parse().map_err(|_| ArklibError::Parse)?;
+        let hash: u32 = r.parse().map_err(|_| ArklibError::Parse)?;
 
-        Ok(ResourceIdCrc32 { data_size, crc32 })
+        Ok(ResourceIdCrc32 { data_size, hash })
     }
 }
 
@@ -55,7 +55,7 @@ impl ResourceIdTrait<'_> for ResourceIdCrc32 {
     type HashType = u32;
 
     fn get_hash(&self) -> Self::HashType {
-        self.crc32
+        self.hash
     }
 
     fn compute<P: AsRef<Path>>(data_size: u64, file_path: P) -> Result<Self> {
@@ -107,12 +107,12 @@ impl ResourceIdTrait<'_> for ResourceIdCrc32 {
                 })?;
         }
 
-        let crc32: u32 = hasher.finalize();
+        let hash: u32 = hasher.finalize();
         log::trace!("[compute] {} bytes has been read", bytes_read);
-        log::trace!("[compute] checksum: {:#02x}", crc32);
+        log::trace!("[compute] checksum: {:#02x}", hash);
         assert_eq!(std::convert::Into::<u64>::into(bytes_read), data_size);
 
-        Ok(ResourceIdCrc32 { data_size, crc32 })
+        Ok(ResourceIdCrc32 { data_size, hash })
     }
 }
 
@@ -150,11 +150,11 @@ mod tests {
     fn resource_id_order() {
         let id1 = ResourceIdCrc32 {
             data_size: 1,
-            crc32: 2,
+            hash: 2,
         };
         let id2 = ResourceIdCrc32 {
             data_size: 2,
-            crc32: 1,
+            hash: 1,
         };
 
         assert!(id1 < id2);

--- a/src/resource/mod.rs
+++ b/src/resource/mod.rs
@@ -13,6 +13,12 @@ mod crc32;
 
 pub use crc32::ResourceIdCrc32 as ResourceId;
 
+/// This trait defines a generic type representing a resource identifier.
+///
+/// Resources are identified by a hash value, which is computed from the resource's data.
+/// The hash value is used to uniquely identify the resource.
+///
+/// Implementors of this trait must provide a way to compute the hash value from the resource's data.
 pub trait ResourceIdTrait<'de>:
     Display
     + FromStr
@@ -26,8 +32,8 @@ pub trait ResourceIdTrait<'de>:
     + Serialize
     + Deserialize<'de>
     + Copy
-{
-    type HashType: Display
+where
+    Self::HashType: Display
         + FromStr
         + Clone
         + PartialEq
@@ -38,12 +44,32 @@ pub trait ResourceIdTrait<'de>:
         + Hash
         + Serialize
         + Deserialize<'de>
-        + Copy;
+        + Copy,
+{
+    /// Associated type representing the hash used by this resource identifier.
+    type HashType;
 
+    /// Returns the hash value of the resource.
     fn get_hash(&self) -> Self::HashType;
 
+    /// Creates a new resource identifier from the given path.
+    ///
+    /// # Arguments
+    /// * `data_size` - Size of the data being identified.
+    /// * `file_path` - Path to the file containing the data.
     fn compute<P: AsRef<Path>>(data_size: u64, file_path: P) -> Result<Self>;
+
+    /// Creates a new resource identifier from raw bytes.
+    ///
+    /// # Arguments
+    /// * `bytes` - Byte array containing the data to be identified.
     fn compute_bytes(bytes: &[u8]) -> Result<Self>;
+
+    /// Creates a new resource identifier from a buffered reader.
+    ///
+    /// # Arguments
+    /// * `data_size` - Size of the data being read.
+    /// * `reader` - Buffered reader providing access to the data.
     fn compute_reader<R: Read>(
         data_size: u64,
         reader: &mut BufReader<R>,

--- a/src/resource/mod.rs
+++ b/src/resource/mod.rs
@@ -32,19 +32,6 @@ pub trait ResourceIdTrait<'de>:
     + Serialize
     + Deserialize<'de>
     + Copy
-where
-    Self::HashType: Display
-        + FromStr
-        + Clone
-        + PartialEq
-        + Eq
-        + Ord
-        + PartialOrd
-        + Debug
-        + Hash
-        + Serialize
-        + Deserialize<'de>
-        + Copy,
 {
     /// Associated type representing the hash used by this resource identifier.
     type HashType;

--- a/src/resource/mod.rs
+++ b/src/resource/mod.rs
@@ -1,0 +1,51 @@
+use core::fmt::Display;
+use core::str::FromStr;
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::io::BufReader;
+use std::io::Read;
+use std::path::Path;
+
+use crate::Result;
+
+mod crc32;
+
+pub use crc32::ResourceIdCrc32 as ResourceId;
+
+pub trait ResourceIdTrait<'de>:
+    Display
+    + FromStr
+    + Clone
+    + PartialEq
+    + Eq
+    + Ord
+    + PartialOrd
+    + Debug
+    + Hash
+    + Serialize
+    + Deserialize<'de>
+    + Copy
+{
+    type HashType: Display
+        + FromStr
+        + Clone
+        + PartialEq
+        + Eq
+        + Ord
+        + PartialOrd
+        + Debug
+        + Hash
+        + Serialize
+        + Deserialize<'de>
+        + Copy;
+
+    fn get_hash(&self) -> Self::HashType;
+
+    fn compute<P: AsRef<Path>>(data_size: u64, file_path: P) -> Result<Self>;
+    fn compute_bytes(bytes: &[u8]) -> Result<Self>;
+    fn compute_reader<R: Read>(
+        data_size: u64,
+        reader: &mut BufReader<R>,
+    ) -> Result<Self>;
+}

--- a/src/resource/mod.rs
+++ b/src/resource/mod.rs
@@ -36,9 +36,6 @@ pub trait ResourceIdTrait<'de>:
     /// Associated type representing the hash used by this resource identifier.
     type HashType;
 
-    /// Returns the hash value of the resource.
-    fn get_hash(&self) -> Self::HashType;
-
     /// Creates a new resource identifier from the given path.
     ///
     /// # Arguments

--- a/src/resource/mod.rs
+++ b/src/resource/mod.rs
@@ -11,7 +11,7 @@ use crate::Result;
 
 mod crc32;
 
-pub use crc32::ResourceIdCrc32 as ResourceId;
+pub use crc32::ResourceId;
 
 /// This trait defines a generic type representing a resource identifier.
 ///

--- a/src/storage/meta.rs
+++ b/src/storage/meta.rs
@@ -3,7 +3,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
 use std::path::Path;
 
-use crate::id::ResourceId;
+use crate::resource::ResourceId;
 use crate::{Result, ARK_FOLDER, METADATA_STORAGE_FOLDER};
 
 pub fn store_metadata<

--- a/src/storage/prop.rs
+++ b/src/storage/prop.rs
@@ -81,7 +81,7 @@ mod tests {
         log::debug!("temporary root: {}", root.display());
 
         let id = ResourceId {
-            crc32: 0x342a3d4a,
+            hash: 0x342a3d4a,
             data_size: 1,
         };
 

--- a/src/storage/prop.rs
+++ b/src/storage/prop.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use std::io::Read;
 use std::path::Path;
 
-use crate::id::ResourceId;
+use crate::resource::ResourceId;
 use crate::util::json::merge;
 use crate::{Result, ARK_FOLDER, PROPERTIES_STORAGE_FOLDER};
 


### PR DESCRIPTION
## Description
This PR aims to make `ResourceIndex` type **generic** over the **hash function** used to generate resource identifiers

Resolves #75
## Changes
- A new trait is implemented named `ResourceIdTrait`. This trait defines a set of functions and requirements that all specific `ResourceId` implementations must implement
- Within `ResourceIdTrait`, a type alias named `HashType` is defined. This allows different `ResourceId` implementations to use different types for their hash values, but we ensure that all `HashType` types implement specific traits for consistent behavior
- Modify `ResourceIdCrc32` type to implement the `ResourceIdTrait`
## Future work
- `src/index.rs` file heavily relies on the assumption of only using `ResourceIdCrc32`. It will require adjustments, potentially including abstracting some tests, to function with various `ResourceId` types.
- We can add conditional compilation easily. for example we can use `ResourceIdBlake3` that implements `ResourceIdTrait` 
- Later, when https://github.com/ARK-Builders/ark-rust/pull/5 is merged, we can move `src/resource` directory into a separate crate for better organization.